### PR TITLE
fix: Migrate web application from FastAPI to Flask

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,20 @@ L'application web, basée sur FastAPI, sert à visualiser les données collecté
 #### Lancer localement
 
 1.  Assurez-vous d'avoir installé les dépendances (`pip install -r requirements.txt`).
-2.  Lancez le serveur de développement Uvicorn depuis le dossier racine :
+2.  Lancez le serveur de développement Flask depuis le dossier racine.
+
+    Sur macOS ou Linux :
     ```bash
-    uvicorn webapp.main:app --reload
+    export FLASK_APP=webapp.main
+    flask run
     ```
-3.  Ouvrez votre navigateur et allez à l'adresse `http://127.0.0.1:8000`.
+
+    Sur Windows (Command Prompt) :
+    ```bash
+    set FLASK_APP=webapp.main
+    flask run
+    ```
+3.  Ouvrez votre navigateur et allez à l'adresse `http://127.0.0.1:5000` (Flask utilise le port 5000 par défaut).
 
 #### Déploiement sur PythonAnywhere
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 requests
 python-decouple
 numpy
-fastapi
-uvicorn[standard]
+flask
 sqlalchemy
 jinja2


### PR DESCRIPTION
This commit refactors the web application from FastAPI to Flask to ensure compatibility with standard WSGI servers like the one used by PythonAnywhere. This resolves a `TypeError` that occurred when the WSGI server tried to run the ASGI-based FastAPI application.

Changes include:
- Updating `requirements.txt` to replace `fastapi` and `uvicorn` with `flask`.
- Rewriting `webapp/main.py` to use Flask syntax for app creation, routing, and template rendering.
- Updating `README.md` with the new local run command for Flask.
- The `wsgi.py` configuration remains compatible.
- A `SyntaxError` in `webapp/main.py` (`is not a None`) was also fixed during testing.