### PR TITLE
fix: Use correct datetime import in data_collector.py

### DIFF
--- a/data_collector.py
+++ b/data_collector.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime
 import json
 from src import api_client, model, probabilities, value_finder
 


### PR DESCRIPTION
This commit fixes an `AttributeError: module 'datetime' has no attribute 'now'`.

The error was caused by using `import datetime` and then calling `datetime.now()`. The import has been changed to `from datetime import datetime` so that `datetime.now()` resolves correctly to the `now()` method on the `datetime` class.