### PR TITLE
fix: Correct usage of date and datetime in data_collector

### DIFF
--- a/data_collector.py
+++ b/data_collector.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, date
 import json
 from src import api_client, model, probabilities, value_finder
 
@@ -14,7 +14,7 @@ def load_allowed_leagues():
 
 def get_daily_fixtures():
     """Fetches all fixtures for the current day."""
-    today = datetime.date.today().strftime('%Y-%m-%d')
+    today = date.today().strftime('%Y-%m-%d')
     endpoint = "fixtures"
     params = {"date": today}
 


### PR DESCRIPTION
This commit fixes an `AttributeError: 'method_descriptor' object has no attribute 'today'`.

This error was a side-effect of a previous fix. The import statement has been updated to `from datetime import datetime, date`, and the call to get the current date has been changed to `date.today()`. This ensures both `datetime.now()` and `date.today()` can be used correctly within the script.