### PR TITLE
fix: Handle non-square score matrices in probability calculations

### DIFF
--- a/src/probabilities.py
+++ b/src/probabilities.py
@@ -34,10 +34,11 @@ def calculate_over_under_probs(score_matrix, threshold=2.5):
     """
     over_prob = 0
     under_prob = 0
-    max_goals = score_matrix.shape[0] - 1
+    max_goals_home = score_matrix.shape[0]
+    max_goals_away = score_matrix.shape[1]
 
-    for i in range(max_goals + 1):
-        for j in range(max_goals + 1):
+    for i in range(max_goals_home):
+        for j in range(max_goals_away):
             if i + j > threshold:
                 over_prob += score_matrix[i, j]
             else:


### PR DESCRIPTION
This commit fixes an `IndexError` that occurred in the `calculate_over_under_probs` function.

The error was caused by assuming the score probability matrix was always square. With the implementation of dynamic grid sizing, the matrix can be rectangular (e.g., 10x7). The iteration logic has been corrected to use the actual dimensions of the matrix (`shape[0]` and `shape[1]`), preventing out-of-bounds access.