### PR TITLE
feat: Migrate data storage to a cloud database for persistence

### DIFF
--- a/.github/workflows/daily_analysis.yml
+++ b/.github/workflows/daily_analysis.yml
@@ -27,13 +27,5 @@ jobs:
       - name: Run data collector
         env:
           API_KEY: ${{ secrets.API_KEY }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
         run: python data_collector.py
-
-      - name: Commit results
-        uses: stefanzweifel/git-auto-commit-action@v4
-        with:
-          commit_message: "chore: Update daily betting results"
-          file_pattern: "results.json"
-          commit_user_name: "GitHub Actions"
-          commit_user_email: "actions@github.com"
-          commit_author: "GitHub Actions <actions@github.com>"

--- a/data_collector.py
+++ b/data_collector.py
@@ -1,6 +1,9 @@
 from datetime import datetime, date
 import json
+from sqlalchemy.orm import Session
 from src import api_client, model, probabilities, value_finder
+import database
+from database import Fixture, ValueBet
 
 def load_allowed_leagues():
     """Loads the list of allowed league IDs from the config file."""
@@ -27,87 +30,100 @@ def get_daily_fixtures():
 
     return response['response']
 
-def run_analysis():
+def analyze_and_store_fixture(db: Session, fixture_data: dict):
     """
-    Runs the full analysis pipeline and returns the results as a list of dicts.
+    Runs the full analysis pipeline and stores the results in the database.
     """
-    if not api_client.API_KEY or api_client.API_KEY == 'VotreCléApiIci':
-        print("ERROR: API key not found or not set. Exiting.")
-        return None
+    try:
+        fixture_id = fixture_data['fixture']['id']
+        fixture_date = datetime.fromtimestamp(fixture_data['fixture']['timestamp']).date()
 
-    all_value_bets = []
-    allowed_league_ids = load_allowed_leagues()
-    fixtures = get_daily_fixtures()
+        # Check if the fixture has already been analyzed
+        existing_fixture = db.query(Fixture).filter(Fixture.id == fixture_id).first()
+        if existing_fixture:
+            print(f"Skipping fixture {fixture_id} (already in DB).")
+            return
 
-    if not fixtures:
-        return []
+        home_team_name = fixture_data['teams']['home']['name']
+        away_team_name = fixture_data['teams']['away']['name']
+        league_name = fixture_data['league']['name']
 
-    print(f"Found {len(fixtures)} total matches for today.")
+        print(f"\nAnalyzing: {home_team_name} vs {away_team_name}")
 
-    if allowed_league_ids:
-        filtered_fixtures = [
-            f for f in fixtures if f.get('league', {}).get('id') in allowed_league_ids
-        ]
-        print(f"Analyzing {len(filtered_fixtures)} matches from your allowed list.")
-    else:
-        filtered_fixtures = fixtures
+        score_matrix, home_lambda, away_lambda = model.calculate_poisson_probabilities(
+            fixture_data['teams']['home']['id'],
+            fixture_data['teams']['away']['id'],
+            fixture_data['league']['id'],
+            fixture_data['league']['season']
+        )
+        if score_matrix is None: return
 
-    for fixture_data in filtered_fixtures:
-        try:
-            fixture_id = fixture_data['fixture']['id']
-            home_team_name = fixture_data['teams']['home']['name']
-            away_team_name = fixture_data['teams']['away']['name']
-            league_name = fixture_data['league']['name']
+        our_probs = probabilities.get_market_probabilities(score_matrix, home_lambda, away_lambda)
+        if not our_probs: return
 
-            print(f"\nAnalyzing: {home_team_name} vs {away_team_name}")
+        bookmaker_odds = value_finder.get_odds_for_fixture(fixture_id)
+        if not bookmaker_odds: return
 
-            score_matrix, home_lambda, away_lambda = model.calculate_poisson_probabilities(
-                fixture_data['teams']['home']['id'],
-                fixture_data['teams']['away']['id'],
-                fixture_data['league']['id'],
-                fixture_data['league']['season']
+        value_bets_found = value_finder.find_value_bets(our_probs, bookmaker_odds)
+
+        if value_bets_found:
+            print(f"--- Storing {len(value_bets_found)} value bets ---")
+
+            # Create Fixture object only if there are bets to store
+            db_fixture = Fixture(
+                id=fixture_id,
+                date=datetime.fromtimestamp(fixture_data['fixture']['timestamp']),
+                home_team_name=home_team_name,
+                away_team_name=away_team_name,
+                league_name=league_name
             )
-            if score_matrix is None: continue
+            db.add(db_fixture)
 
-            our_probs = probabilities.get_market_probabilities(score_matrix, home_lambda, away_lambda)
-            if not our_probs: continue
+            for bet in value_bets_found:
+                db_bet = ValueBet(
+                    fixture_id=fixture_id,
+                    market=bet['market'],
+                    bet_value=bet['value'],
+                    probability=bet['prob'],
+                    odds=bet['odds'],
+                    value=(bet['prob'] * bet['odds'])
+                )
+                db.add(db_bet)
 
-            bookmaker_odds = value_finder.get_odds_for_fixture(fixture_id)
-            if not bookmaker_odds: continue
+            db.commit()
+        else:
+            print("No value bets found.")
 
-            value_bets_found = value_finder.find_value_bets(our_probs, bookmaker_odds)
-
-            if value_bets_found:
-                print(f"--- Found {len(value_bets_found)} value bets ---")
-                for bet in value_bets_found:
-                    bet_details = {
-                        "match": f"{home_team_name} vs {away_team_name}",
-                        "league": league_name,
-                        "market": bet['market'],
-                        "bet_value": bet['value'],
-                        "probability": bet['prob'],
-                        "odds": bet['odds'],
-                        "value": bet['prob'] * bet['odds'],
-                        "timestamp": datetime.now().isoformat()
-                    }
-                    all_value_bets.append(bet_details)
-            else:
-                print("No value bets found.")
-
-        except (KeyError, TypeError) as e:
-            print(f"Error processing fixture {fixture_data.get('fixture', {}).get('id', 'N/A')}. Missing data: {e}")
-
-    return all_value_bets
+    except (KeyError, TypeError) as e:
+        print(f"Error processing fixture {fixture_data.get('fixture', {}).get('id', 'N/A')}. Missing data: {e}")
+        db.rollback()
 
 
 if __name__ == "__main__":
-    print("Starting data collection...")
-    results = run_analysis()
-
-    if results is not None:
-        with open("results.json", "w") as f:
-            json.dump(results, f, indent=4)
-        print(f"\nData collection complete. Found {len(results)} value bets.")
-        print("Results saved to results.json")
+    if not api_client.API_KEY or not database.DATABASE_URL:
+        print("ERROR: API_KEY or DATABASE_URL not found.")
+        print("Please ensure they are set as environment variables or in a .env file.")
     else:
-        print("\nData collection failed.")
+        print("Initializing database...")
+        database.init_db()
+        db = database.SessionLocal()
+
+        allowed_league_ids = load_allowed_leagues()
+        fixtures = get_daily_fixtures()
+
+        if fixtures:
+            print(f"Found {len(fixtures)} total matches for today.")
+
+            if allowed_league_ids:
+                filtered_fixtures = [
+                    f for f in fixtures if f.get('league', {}).get('id') in allowed_league_ids
+                ]
+                print(f"Analyzing {len(filtered_fixtures)} matches from your allowed list.")
+            else:
+                filtered_fixtures = fixtures
+
+            for fixture_data in filtered_fixtures:
+                analyze_and_store_fixture(db, fixture_data)
+
+        db.close()
+        print("\nData collection complete.")

--- a/database.py
+++ b/database.py
@@ -1,0 +1,52 @@
+import os
+from sqlalchemy import create_engine, Column, Integer, String, Float, DateTime, ForeignKey
+from sqlalchemy.orm import sessionmaker, relationship, declarative_base
+from decouple import config
+import datetime
+
+# Get the database URL from environment variables, provided by GitHub Secrets
+DATABASE_URL = config("DATABASE_URL", default=None)
+
+if DATABASE_URL:
+    engine = create_engine(DATABASE_URL)
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+else:
+    # This is a fallback for local testing without a DB, though the script will fail on API key.
+    # A better local setup would use a local Postgres or SQLite DB.
+    print("WARNING: DATABASE_URL not found. Using in-memory SQLite database.")
+    engine = create_engine("sqlite:///:memory:")
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()
+
+class Fixture(Base):
+    __tablename__ = "fixtures"
+
+    id = Column(Integer, primary_key=True, index=True) # Fixture ID from API
+    date = Column(DateTime, default=datetime.datetime.utcnow)
+    home_team_name = Column(String, index=True)
+    away_team_name = Column(String, index=True)
+    league_name = Column(String, index=True)
+
+    value_bets = relationship("ValueBet", back_populates="fixture", cascade="all, delete-orphan")
+
+class ValueBet(Base):
+    __tablename__ = "value_bets"
+
+    id = Column(Integer, primary_key=True, index=True, autoincrement=True)
+    fixture_id = Column(Integer, ForeignKey("fixtures.id"))
+    market = Column(String)
+    bet_value = Column(String) # e.g., 'Home', 'Over', 'Yes'
+    probability = Column(Float)
+    odds = Column(Float)
+    value = Column(Float) # The result of prob * odds
+
+    fixture = relationship("Fixture", back_populates="value_bets")
+
+def init_db():
+    """
+    Initializes the database and creates tables if they don't exist.
+    """
+    if not engine:
+        raise Exception("Database engine not initialized. DATABASE_URL may be missing.")
+    Base.metadata.create_all(bind=engine)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ numpy
 streamlit
 pandas
 scipy
+psycopg2-binary


### PR DESCRIPTION
This commit refactors the application to use a cloud-hosted PostgreSQL database (via Supabase) instead of a `results.json` file. This change enables persistent storage of betting history, allowing for long-term analysis and performance tracking.

Key changes:
- `psycopg2-binary` added to requirements for Postgres connection.
- A new `database.py` module manages the database connection using a `DATABASE_URL` environment variable.
- `data_collector.py` is refactored to connect to the database and insert new value bets, creating a historical record.
- `streamlit_app.py` is refactored to read the full history of bets from the database, rather than a single JSON file.
- The GitHub Actions workflow is updated to pass the `DATABASE_URL` secret and no longer commits a JSON file.