### PR TITLE
fix: Add missing sqlalchemy dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ numpy
 streamlit
 pandas
 scipy
+sqlalchemy
 psycopg2-binary


### PR DESCRIPTION
This commit re-adds the `sqlalchemy` library to the `requirements.txt` file.

It was accidentally removed during a previous refactoring, which caused the GitHub Actions workflow to fail with a `ModuleNotFoundError`. This fix ensures all necessary dependencies are installed for the data collector to run.